### PR TITLE
Minor editorial issues around extensions.

### DIFF
--- a/draft-vvv-tls-alps.md
+++ b/draft-vvv-tls-alps.md
@@ -143,8 +143,8 @@ exchange is performed in three steps:
 
                                                        ServerHello
                                              {EncryptedExtensions}
-                                                          + {alpn}
-                                                          + {alps}
+                                                            + alpn
+                                                            + alps
                                                                ...
                                  <--------              {Finished}
 
@@ -226,7 +226,7 @@ carried over from the previous connection.
 
 IANA will update the "TLS ExtensionType Values" registry to include
 `application_settings` with the value of TBD; the list of messages in which
-this extension may appear is `CH, SH`.
+this extension may appear is `CH, EE`.
 
 IANA will also update the "TLS HandshakeType" registry to include
 `client_application_settings` message with value TBD, and "DTLS-OK" set to "Y".


### PR DESCRIPTION
The new extension is CH,EE, not CH,SH. Also, going by RFC8446 section
2.3, looks like we don't put curly braces around the + extension_name
bits, even when encrypted.